### PR TITLE
Add Electron front-end support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ Rime 配置教程：
 
 1. 安装[Rime输入法](https://rime.im/)并注销或重启电脑；
 2. 下载本仓库所有配置文件到本地rime配置文件；
+   - 若在 Electron 应用中集成 Rime，请将文件复制到应用的 rime 目录
+     （如 Windows 的 `%APPDATA%\\<app-name>\\rime` 或 Linux/macOS 的
+     `~/.config/<app-name>/rime`），并确保包含 `electron.yaml`；
 3. 重新部署Rime
 4. 开始使用
 5. 根据自己习惯，进行二次修改
@@ -68,6 +71,9 @@ Rime 配置教程：
   - iBus:`~/.config/ibus/rime`
   - Fcitx5: `~/.local/share/fcitx5/rime`
 - Fctix5 Android(小企鹅入法): `/storage/emulated/0/Android/data/org.fcitx.fcitx5.android/files/data/rime/`
+- Electron 应用: 取决于应用名称，通常在
+  - Windows: `%APPDATA%\\<app-name>\\rime`
+  - macOS/Linux: `~/.config/<app-name>/rime`
 
 本地rime日志文件默认地址如下：
 
@@ -90,6 +96,7 @@ Rime 配置教程：
 - `default.yaml` 设置输入法、如何切换输入法、翻页等；建议自行创建`default.custom.yaml`来覆写薄荷配置的`default.yaml`.
 - `squirrel.yaml` 鼠须管( Mac 版本 )设置哪些软件默认英文输入，输入法皮肤等；如需自定义，建议自行创建`squirrel.custom.yaml`来覆写。
 - `weasel.yaml` 小狼毫( Win 版本 )设置哪些软件默认英文输入，输入法皮肤等；如需自定义，建议自行创建`weasel.custom.yaml`来覆写。
+- `electron.yaml` Electron 前端配置文件，在将薄荷输入法嵌入 Electron 应用时使用，可创建 `electron.custom.yaml` 进行覆写。
 
 配置文件中大部分都有注释，配合教程：[配置覆写](https://www.mintimate.cc/zh/guide/configurationOverride.html)
 

--- a/README_en.md
+++ b/README_en.md
@@ -46,6 +46,9 @@ The following tutorials are available for Linux, macOS and Windows (Xp~)
 
 1. Install [Rime Input Method](https://rime.im/) and log out or restart the computer;
 2. Download all the configuration files of this warehouse to the local rime configuration file;
+   - When embedding Rime into an Electron application, copy these files to the application's rime directory
+     (e.g. `%APPDATA%\\<app-name>\\rime` on Windows or `~/.config/<app-name>/rime` on Linux/macOS)
+     and make sure `electron.yaml` is present;
 3. Redeploy Rime;
 4. Get started
 5. Make secondary modifications according to your own habits
@@ -62,6 +65,9 @@ The default address of the local rime configuration file is as follows
   - iBus: `~/.config/ibus/rime`
   - Fcitx5: `~/.local/share/fcitx5/rime`
 - Fctix5 Android: `/storage/emulated/0/Android/data/org.fcitx.fcitx5.android/files/data/rime/`
+- Electron app: depends on the application name, usually located at
+  - Windows: `%APPDATA%\\<app-name>\\rime`
+  - macOS/Linux: `~/.config/<app-name>/rime`
 
 The default address of the local rime log file is as follows:
 -Windows
@@ -86,6 +92,7 @@ If you like to use Rime to type long sentences, it is strongly recommended to us
 - `default.yaml` set the input method, how to switch the input method, turn the page, etc.
 - `squirrel.yaml` Mac version to set which software defaults to English input, input method skin, etc.
 - `weasel.yaml` Win version to set which software defaults to English input, input method skin, etc.
+- `electron.yaml` Configuration for Electron front-ends. Place it in the application's rime directory when embedding Oh-my-rime into an Electron app, and override via `electron.custom.yaml` if needed.
 
 Most of the configuration files are commented. Cooperate with the tutorial: [Configuration Overrides and Customization](https://www.mintimate.cc/en/guide/configurationOverride.html)
 

--- a/README_zh-cn.md
+++ b/README_zh-cn.md
@@ -49,6 +49,9 @@ Rime 配置教程：
 
 1. 安装[Rime输入法](https://rime.im/)并注销或重启电脑；
 2. 下载本仓库所有配置文件到本地rime配置文件；
+   - 若在 Electron 应用中集成 Rime，请将文件复制到应用的 rime 目录
+     （如 Windows 的 `%APPDATA%\\<app-name>\\rime` 或 Linux/macOS 的
+     `~/.config/<app-name>/rime`），并确保包含 `electron.yaml`；
 3. 重新部署Rime
 4. 开始使用
 5. 根据自己习惯，进行二次修改
@@ -68,6 +71,9 @@ Rime 配置教程：
   - iBus:`~/.config/ibus/rime`
   - Fcitx5: `~/.local/share/fcitx5/rime`
 - Fctix5 Android(小企鹅入法): `/storage/emulated/0/Android/data/org.fcitx.fcitx5.android/files/data/rime/`
+- Electron 应用: 取决于应用名称，通常在
+  - Windows: `%APPDATA%\\<app-name>\\rime`
+  - macOS/Linux: `~/.config/<app-name>/rime`
 
 本地rime日志文件默认地址如下：
 
@@ -90,6 +96,7 @@ Rime 配置教程：
 - `default.yaml` 设置输入法、如何切换输入法、翻页等；建议自行创建`default.custom.yaml`来覆写薄荷配置的`default.yaml`.
 - `squirrel.yaml` 鼠须管( Mac 版本 )设置哪些软件默认英文输入，输入法皮肤等；如需自定义，建议自行创建`squirrel.custom.yaml`来覆写。
 - `weasel.yaml` 小狼毫( Win 版本 )设置哪些软件默认英文输入，输入法皮肤等；如需自定义，建议自行创建`weasel.custom.yaml`来覆写。
+- `electron.yaml` Electron 前端配置文件，在将薄荷输入法嵌入 Electron 应用时使用，可创建 `electron.custom.yaml` 进行覆写。
 
 配置文件中大部分都有注释，配合教程：[配置覆写](https://www.mintimate.cc/zh/guide/configurationOverride.html)
 

--- a/default.yaml
+++ b/default.yaml
@@ -4,6 +4,10 @@
 # Fork From: https://github.com/rime/librime/blob/3bc65c990546aa2062ecd1eb593d54d2949644cd/data/minimal/default.yaml
 config_version: "24.03.24"
 
+# When running inside an Electron application (for example using
+# electron-rime), place `electron.yaml` alongside this file so that
+# the Electron front-end can load its specific settings.
+
 # 以下内容，实际会由default.custom.yaml和方案配置所覆写
 ## 九宫格依赖于 rime_mint ，如果需要使用其他方案（比如: 小鹤双拼的 九宫格），可以使用 custom 文件覆写
 schema_list:
@@ -14,6 +18,8 @@ schema_list:
   - schema: wubi98_mint          # 五笔98-五笔小筑
   - schema: wubi86_jidian        # 五笔86-极点86
   - schema: t9                   # 仓九宫格-全拼输入
+  # Electron front-ends use the same schema list but require
+  # `electron.yaml` for UI configuration.
   # 以下方案薄荷进行了适配，但是没有激活
   # - schema: double_pinyin_abc    # 智能ABC双拼
   # - schema: double_pinyin_mspy   # 微软双拼

--- a/electron.yaml
+++ b/electron.yaml
@@ -1,0 +1,20 @@
+# Electron settings
+# encoding: utf-8
+
+# Rime configuration for Electron-based front-ends.
+# Copy this file into the rime directory used by your Electron application.
+
+config_version: '2024-09-14'
+
+style:
+  color_scheme: mint_light_blue
+  color_scheme_dark: mint_dark_blue
+  inline_preedit: true
+  text_orientation: horizontal
+  candidate_list_layout: stacked
+  horizontal: false
+  remember_size: false
+  font_face: 'PingFang SC'
+  font_point: 14
+  label_font_point: 14
+  comment_font_point: 12


### PR DESCRIPTION
## Summary
- add `electron.yaml` for Electron-based front-ends
- mention electron settings in `default.yaml`
- document Electron usage paths in README files

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684a34c468d083259bdc8c0a92dc124f